### PR TITLE
Single access point strategy for commonly needed client js data

### DIFF
--- a/controllers/api/spaceMemberRoutes.js
+++ b/controllers/api/spaceMemberRoutes.js
@@ -4,7 +4,6 @@ const { withAuthJson } = require('../../utils/auth');
 
 router.post('/:space_id/member', withAuthJson, async (req, res) => {
   try {
-    console.log( req.params );
     const { space_id } = req.params;
     const { user_id } = req.session;
 

--- a/docs/ClientContext.md
+++ b/docs/ClientContext.md
@@ -3,16 +3,29 @@
 Some data, just `req.params` by default, is automatically made available to client side javascript through the global method `getContext()`.
 
 ## Usage
+
+The most common usage, will be accessing `:param` data in client side event handlers. Below is an example showing how to fetch the `:space_id` param and build it into an api request path.
 ```js
 const myEventHandler = async (event) => {
-    // We no longer needed to store/access the :param data from elements
+    // Instead of storeing/accessing `:param` data from elements.
     // const space_id = event.target.dataset.id;
 
-    // Instead, we can pull it out of my newly provided "context" object, accessed via `getContext()`.
+    // We can pull it out of the globally provided "context" object, accessed via `getContext()`.
     // Get the space ID from global context.
     const { space_id } = getContext();
+
+    try {
+        const response = await fetch( `/api/space/${space_id}` );
+        // response handling
+    } catch(err) {
+        // error handling
+    }
 }
 ```
+
+## Extending `jsViewContext`: Adding more data to `getContext()`
+
+To be written!
 
 ## FAQ
 
@@ -26,4 +39,4 @@ Middleware in the Express layer helps automatically provide a `jsViewContext` va
 
 That object is printed as JSON in inside a `closure` where the `getContext` method is created.
 
-Since this is done at the top of the page, for all the views, the `getContext` method becomes global method accessible from any view js file.
+Since this is done at the top of the page, for all of the views, the `getContext` method becomes a global method accessible from any client side js file linked within a view.

--- a/docs/ClientContext.md
+++ b/docs/ClientContext.md
@@ -1,0 +1,29 @@
+# Client Side Context Data
+
+Some data, just `req.params` by default, is automatically made available to client side javascript through the global method `getContext()`.
+
+## Usage
+```js
+const myEventHandler = async (event) => {
+    // We no longer needed to store/access the :param data from elements
+    // const space_id = event.target.dataset.id;
+
+    // Instead, we can pull it out of my newly provided "context" object, accessed via `getContext()`.
+    // Get the space ID from global context.
+    const { space_id } = getContext();
+}
+```
+
+## FAQ
+
+**Where does the `getContext()` come from?**
+
+If you're looking for the function definition, you can find it's creation in the <head> of the main layout file in handlebars.
+
+**How does it work?**
+
+Middleware in the Express layer helps automatically provide a `jsViewContext` variable to handlebars views. `jsViewContext` is an object, currently just a match of `req.params` by default.
+
+That object is printed as JSON in inside a `closure` where the `getContext` method is created.
+
+Since this is done at the top of the page, for all the views, the `getContext` method becomes global method accessible from any view js file.

--- a/docs/ClientContext.md
+++ b/docs/ClientContext.md
@@ -39,4 +39,4 @@ Middleware in the Express layer helps automatically provide a `jsViewContext` va
 
 That object is printed as JSON in inside a `closure` where the `getContext` method is created.
 
-Since this is done at the top of the page, for all of the views, the `getContext` method becomes a global method accessible from any client side js file linked within a view.
+Since this is done at the top of the page, for all of the views, `getContext()` becomes a globally accessible method from any client side js file linked within a view.

--- a/public/js/access.js
+++ b/public/js/access.js
@@ -1,6 +1,9 @@
 (() => {
-  const joinSpace = async ({ target }) => {
-    const space_id = target.dataset.id;
+  const joinSpace = async () => {
+    // const space_id = target.dataset.id;
+
+    // Get the space ID from global context.
+    const { space_id } = getContext();
 
     const response = await fetch(`/api/space/${space_id}/member`, {
       method: 'POST',

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -20,4 +20,5 @@ module.exports = {
       return false;
     }, false);
   },
+  as_json: (data) => JSON.stringify(data)
 };

--- a/utils/renderWithAppData.js
+++ b/utils/renderWithAppData.js
@@ -6,6 +6,7 @@ const renderWithAppData = async (req, res, next) => {
 
   req.viewData = {
     loggedIn,
+    jsViewContext: {}
   };
 
   if (loggedIn && user_id) {
@@ -26,6 +27,10 @@ const renderWithAppData = async (req, res, next) => {
     render(name, {
       ...(data ? data : {}),
       ...req.viewData,
+      jsViewContext: {
+        ...req.viewData.jsViewContext,
+        ...req.params
+      }
     });
 
   return next();

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -48,7 +48,14 @@
     ></script>
 
     <script>
-      const viewContext = {{{as_json jsViewContext}}};
+      const getContext = (() => {
+        {{! /*Scope the context data to privately secure it from tampering*/ }}
+        const viewContext = {{{as_json jsViewContext}}};
+        return ( key ) => {
+          {{! /*If given a key, return that one prop, else return the whole context*/ }}
+          return key ? viewContext[key] : viewContext;
+        }
+      })();
     </script>
   </head>
 

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -47,6 +47,9 @@
       src='https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js'
     ></script>
 
+    <script>
+      const viewContext = {{{as_json jsViewContext}}};
+    </script>
   </head>
 
   <body>

--- a/views/space-access.handlebars
+++ b/views/space-access.handlebars
@@ -1,6 +1,6 @@
 <div class="row gx-5">
     <div class="col-md-auto">
-        <button class="btn btn-lg px-5 py-4 btn-primary shadow-lg mb-5 mb-md-0" data-id="{{space_id}}" id="access-space">Request Access</button>
+        <button class="btn btn-lg px-5 py-4 btn-primary shadow-lg mb-5 mb-md-0" id="access-space">Request Access</button>
     </div>
 
     <div class="col-md">


### PR DESCRIPTION
Had this thought for easing some dev pains in client code. This code helps avoid not always having to think about printing the current space id, or idea id somewhere on the page, so you can grab it later from an element for your POST/PUT requests. This solution will make that sort of data automatically available through a global method `getContext()`.

Note, below, more info can be found in the newly added doc file:
https://github.com/jmichaelbrown8/elevator-pitch/blob/feature/params-as-client-js-data/docs/ClientContext.md

**Details**
- Pass req.params to the view as `jsViewContext`.
- Print the `jsViewContext` as scoped json data accessible through the `getContext()` method.
- Added `as_json` handlebar helper to assist with rendering the data as a json string.
- `jsViewContext` is extensible through additional middleware (so other things can potentially add on to it in the future). *Extensibility not yet documented*.

**Live Code Example**
I've converted the event handler for the "request access" button to grab the `space_id` from `getContext()`.
https://github.com/jmichaelbrown8/elevator-pitch/blob/feature/params-as-client-js-data/public/js/access.js

**Usage**
Can be used within client side event handers to request and variables that were built in as Express `:params`.

For example, all space related routes will have the param `:space_id` in the route, which provides access to `space_id` in the `getContext()` object.
```js
const myEventHandler = async (event) => {
    // We no longer needed to store/access the space id from elements
    // const space_id = event.target.dataset.id;

    // Instead, we can pull it out of my newly provided "context" object, accessed via `getContext()`.
    // Get the space ID from global context.
    const { space_id } = getContext();
}
```