### PR TITLE
Patch / Login Persistence

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,10 +22,11 @@ const hbs = exphbs.create({
 const sess = {
   secret: process.env.SESSION_SECRET || 'Replace me',
   cookie: {
-    // Stored in milliseconds (1800000 === 30 minutes)
-    maxAge: 1800000,
+    // Stored in milliseconds (43200000 === 12 hours)
+    maxAge: 43200000,
   },
   resave: false,
+  rolling: true,
   saveUninitialized: true,
   store: new SequelizeStore({
     db: sequelize,


### PR DESCRIPTION
Update to session config to enable rolling cookies and increase timeout to 12 hours.

- Set session config `rolling` to `true`
- Increased `cookie.maxAge` to `43200000` (12 hours in milliseconds)

resolves #98 