### PR TITLE
Feature/smart login redirects

### DIFF
--- a/controllers/api/userRoutes.js
+++ b/controllers/api/userRoutes.js
@@ -1,15 +1,28 @@
 const router = require('express').Router();
 const { User } = require('../../models');
 
+const popSessionRedirectUrl = (req) => {
+  const redirect = req.session.authRedirectedFrom;
+
+  if (redirect) {
+    delete req.session.authRedirectedFrom;
+  }
+
+  return redirect;
+};
+
 router.post('/', async (req, res) => {
   try {
     const userData = await User.create(req.body);
+
+    const redirect = popSessionRedirectUrl(req);
 
     req.session.user_id = userData.id;
     req.session.loggedIn = true;
 
     req.session.save(() => {
       res.status(200).json({
+        redirect,
         message: `User ${userData.name} created`,
       });
     });
@@ -43,6 +56,8 @@ router.post('/login', async (req, res) => {
       };
     }
 
+    const redirect = popSessionRedirectUrl(req);
+
     req.session.user_id = userData.id;
     req.session.loggedIn = true;
 
@@ -50,6 +65,7 @@ router.post('/login', async (req, res) => {
       res.json({
         // user: userData,
         message: `You are now logged in!`,
+        redirect,
       });
     });
   } catch (err) {

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -17,7 +17,8 @@ const loginFormHandler = async (event) => {
 
     if (response.ok) {
       localStorage.setItem('toast', 'You are now logged in.');
-      document.location.replace('/');
+      const { redirect } = await response.json();
+      document.location.replace(redirect || '/');
     } else {
       localStorage.setItem('toast', 'Failed to log in.');
       toastIt(true);

--- a/public/js/signup.js
+++ b/public/js/signup.js
@@ -19,7 +19,8 @@ const signupFormHandler = async (event) => {
 
     if (response.ok) {
       localStorage.setItem('toast', `Welcome ${name}! Let's create.`);
-      document.location.replace('/');
+      const { redirect } = await response.json();
+      document.location.replace(redirect || '/');
     } else {
       localStorage.setItem('toast', 'Failed to sign up.');
       toastIt(true);

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -194,8 +194,10 @@ const withNoMembership = (req, res, next) => {
   next();
 };
 
-const withAuth = (req, res, next) => {
+const withAuth = async (req, res, next) => {
   if (!req.session.loggedIn) {
+    req.session.authRedirectedFrom = req.originalUrl;
+    await req.session.save();
     res.redirect('/login');
   } else if (req.authState && !req.authState.valid) {
     // If previous middleware invalidated `req.authState`, redirect the user


### PR DESCRIPTION
Adds a strategy to store user's original url when hitting an auth redirect so that we can then send the user to that URL after they complete the login/sign up process.

**How to test**
- Get the URL for a space/idea page
- Make sure you are logged out
- Try to navigate directly to the space URL (paste into address bar) to trigger auth redirect to log in
- Complete a login or signup
- [x] You get redirected to the space/idea page (Or space access page if the user is not already an approved member)

resolves #97 