### PR TITLE
Updates add resource to only idea owners. Wraps texts on links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "elevator-pitch",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/views/idea.handlebars
+++ b/views/idea.handlebars
@@ -95,10 +95,11 @@
     </div>
    
     <div class="row gy-4">
+          {{#if is_owner}}    
         <div class="col-md-6 col-xl-4 col-xxl-3">
             <div class="card card-body card-tile bg-light shadow-sm" data-bs-toggle="modal" data-bs-target="#resource-modal" >
           
-                <a class="overlay-hover inner-down-hover bg-success text-white shadow"  style="--bs-bg-opacity: 0.85">
+                <a class="overlay-hover inner-down-hover bg-success text-white shadow"  style="--bs-bg-opacity: 0.85; cursor:pointer">
                     <span class="d-block px-4 py-3 fs-4 fw-bold text-center" >
                         <span>
                         Create a New<br/></span>
@@ -106,6 +107,7 @@
                     </span>
                 </a>
                 {{!-- </a> --}}
+              
                 <p class="m-0 overlay-hover--hide inner-down-hover--also fs-4 d-block text-center" data-bs-toggle="modal" data-bs-target="#resource-modal" >
                     <span class="badge fs-5 bg-success bi-plus-circle"> Add New</span>
                     <span class="d-block mt-2">
@@ -114,13 +116,14 @@
                 </p>
             </div>
         </div>
+                {{/if}}
 
 {{!-- current resources --}}
            
  {{#each resources}}
     
-        <div class="col-md-6 col-xl-4 col-xxl-3">
-            <div class="card card-body card-tile bg-light shadow-sm">
+        <div class="col-md-6 col-xl-4 col-xxl-3 ">
+            <div class="card card-body card-tile bg-light shadow-sm text-wrap">
                 {{#unless (is_match type 'link')}}
                 <a href="/space/{{../idea.space_id}}/idea/{{../idea.id}}/resource/{{id}}" 
                     {{/unless}}
@@ -128,9 +131,11 @@
                  <a href='{{content}}' target="_blank" 
                 {{/if}}
                     class="overlay-hover inner-down-hover bg-primary text-white shadow" style="--bs-bg-opacity: 0.85">
-                    <span class="d-block px-4 py-3 fs-4 fw-bold text-center">
+                    <span class="d-block px-4 fs-4 fw-bold text-center text-wrap">
                         View Resource<br/>
-                        <span class="fw-normal fs-5 resource-content">{{content}}</span>
+                        {{#if (is_match type 'link')}}
+                        <span class="fw-normal badge text-wrap fs-6 resource-content w-75 lh-sm" >{{content}}</span>
+                        {{/if}}
                     </span>
                 </a>
 

--- a/views/idea.handlebars
+++ b/views/idea.handlebars
@@ -131,7 +131,7 @@
                  <a href='{{content}}' target="_blank" 
                 {{/if}}
                     class="overlay-hover inner-down-hover bg-primary text-white shadow" style="--bs-bg-opacity: 0.85">
-                    <span class="d-block px-4 fs-4 fw-bold text-center text-wrap">
+                    <span class="d-block px-4 py-3 fs-4 fw-bold text-center text-wrap">
                         View Resource<br/>
                         {{#if (is_match type 'link')}}
                         <span class="fw-normal badge text-wrap fs-6 resource-content w-75 lh-sm" >{{content}}</span>

--- a/views/resource.handlebars
+++ b/views/resource.handlebars
@@ -49,9 +49,9 @@
   </div>
 </div>
 
-
+{{#if is_owner}}
 <div class="card card-body bg-light shadow-sm mt-3" data-bs-toggle="modal" data-bs-target="#resource-modal">
-  <a class="overlay-hover inner-down-hover bg-success text-white shadow" style="--bs-bg-opacity: 0.85">
+  <a class="overlay-hover inner-down-hover bg-success text-white shadow" style="--bs-bg-opacity: 0.85; cursor:pointer">
     <span class="d-block px-4 py-3 fs-4 fw-bold text-center">
       <span>
         Create a New<br /></span>
@@ -66,10 +66,10 @@
     </span>
   </p>
 </div>
+{{/if}}
 
 {{!-- modal for inserting a resource --}}
 {{> modals/resourceMini}}
-
 
 {{!-- modal for editing a resource --}}
 {{> modals/editResourceMini}}


### PR DESCRIPTION
- [x] Should only be able to add a resource (and see the 'Add resource' box) if you're the idea owner. 
(Not idea owner)
![image](https://user-images.githubusercontent.com/92805933/161316664-156bc66a-33d6-44a3-988e-b3e3c7e2bf79.png)

- [x] Also updates the link wrapping when previewing a link. It now stays within the box :)

![image](https://user-images.githubusercontent.com/92805933/161316552-ce3e0ab7-2c29-44da-972d-4a8c3dfb7e38.png)
Resolves #119 